### PR TITLE
Add Nix Kind2 Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ This is main repository for the PSU capstone.
 * `Arduino` contains a demo library for embedding Rust code into arduino projects, as well as example sketch
 * `rust-lib` is a demo Rust library
 
+## Setting up the Environment
+Kind2 isn't distributed on common managers and can be tricky to build. Has been successfully built on Ubuntu 18.04 during the last capstone. If it is necessary to build kind2 from source, ensure that Ocaml 4.04 is present. Also, depending on the source hash, some compiler flags will need to be modified; for the version packaged, the `-Werror` command was removed from czmq and libczmq. 
+
+The verification tools have been packaged in Nix. There is a package description in the `kind2` folder. If nix isn't installed on the system, run
+```
+cd nix && sh bootstrap-nix.sh
+```
+Alternatively, if Nix is installed, 
+```
+cd nix
+nix-shell # To get an interactive shell with kind2 in PATH
+nix-build # To get a sym link to kind in ./result
+```
+can be run. 
+
+NOTE: *If using WSL in Windows 10 prior to the creators update, the Nix package will fail to install properly.* This can be fixed by following [these instructions](https://dev.to/notriddle/installing-nix-under-wsl-2eim).
+
 ## Using Rust in Arduino projects
 1. `cd rust-lib/ && ./build.sh && cd ..`
 2. `cp rust-lib/libFoo.a Arduino/libraries/Foo/src/cortex-m0plus/.`

--- a/nix/bootstrap-nix.sh
+++ b/nix/bootstrap-nix.sh
@@ -1,0 +1,6 @@
+if ! type -P nix; then
+	curl https://nixos.org/nix/install | sh
+fi	
+nix-build
+nix-shell
+

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,4 @@
+let
+  pkgs = import <nixpkgs> {};
+in 
+  pkgs.callPackage ./verification/kind2.nix {}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,53 @@
+{}:
+
+let
+  pkgs = import <nixpkgs> {};
+                    
+  git-prompt = with pkgs; fetchFromGitHub {
+    "owner" = "magicmonty";
+    "repo" = "bash-git-prompt";
+    "rev" = "148d502b666a0d62ecc83680817596b097a70f2a";
+    "sha256" = "0xdyyc0lvfrxg9bgmiy4h22y0wp6x3yn6md6jy2f7kcw8dww9pyz";
+  };
+  
+  # Use Ocaml 4.04
+  my-ocaml = pkgs.ocaml-ng.ocamlPackages_4_04.ocaml;
+  my-ocaml-packages = pkgs.ocaml-ng.ocamlPackages_4_04;
+
+  kind2 =  pkgs.callPackage ./verification/kind2.nix { };
+
+  llvmCross = pkgs.llvmPackages_9.llvm;
+  clangCross = pkgs.llvmPackages_9.clang;
+  lldCross = pkgs.llvmPackages_9.lld;
+in 
+  with pkgs; mkShell {
+    buildInputs = [
+            
+      #Kind2 Setup
+      kind2
+      z3
+
+      # Build Tools Setup
+      automake
+      autoconf
+      libtool
+      pkgconfig
+            
+      # OCaml Setup
+      my-ocaml
+      my-ocaml-packages.findlib
+      my-ocaml-packages.ocamlbuild
+      my-ocaml-packages.menhir
+      my-ocaml-packages.num
+      my-ocaml-packages.yojson
+
+      # Cross Compilation Tools
+      llvmCross
+      clangCross
+      lldCross
+
+    ];
+    
+    shellHook = "source ${git-prompt}/gitprompt.sh";
+
+  }

--- a/nix/verification/czmq-configure.patch
+++ b/nix/verification/czmq-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/ocamlczmq/czmq/configure.ac b/ocamlczmq/czmq/configure.ac
+index ba218e69..69b18568 100755
+--- a/ocamlczmq/czmq/configure.ac
++++ b/ocamlczmq/czmq/configure.ac
+@@ -297,7 +297,7 @@ AC_C_BIGENDIAN
+ 
+ # These options are GNU compiler specific.
+ if test "x$GCC" = "xyes"; then
+-    CPPFLAGS="-pedantic -Werror -Wall -Wc++-compat ${CPPFLAGS}"
++    CPPFLAGS="-pedantic -Wall -Wc++-compat ${CPPFLAGS}"
+ fi
+ 
+ AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")

--- a/nix/verification/kind2.nix
+++ b/nix/verification/kind2.nix
@@ -1,0 +1,122 @@
+{ stdenv
+, fetchFromGitHub
+, python3 
+, automake
+, autoconf
+, libtool
+, pkgconfig
+, autoreconfHook
+, ocaml-ng
+, smtType ? "Z3"
+, enableManPages ? false
+, z3
+, yices
+, cvc4
+, texlive  
+, lmodern  }:
+
+let
+    # the documentation requires a specific LaTeX environment 
+    texliveMk = texlive.combine { inherit (texlive) 
+                                  scheme-medium 
+                                  latexmk 
+                                  titlesec 
+                                  tabulary 
+                                  varwidth 
+                                  framed 
+                                  wrapfig 
+                                  upquote 
+                                  capt-of 
+                                  needspace 
+                                  tocloft 
+                                  datetime 
+                                  lastpage 
+                                  blindtext 
+                                  xpatch 
+                                  enumitem 
+                                  fmtcount; };
+in stdenv.mkDerivation {
+  
+  pname = "kind2";
+
+  # Pulled from development branch
+  version = "1.1.0-dev";
+
+  outputs = [ "out" ] ++ stdenv.lib.optional enableManPages "doc";
+
+  src =  fetchFromGitHub {
+    owner = "kind2-mc";
+    repo = "kind2";
+    rev = "96773521641cef2a7962630ff9d11074e38e778a";
+    sha256 = "19s7haxzc8ymlqcvxj8rnm6x9nk5c1161ya1c9s2a3rzwq56ammx";
+  };
+
+  # Building with -Werror fails, get rid of it
+  patches = [ 
+    ./czmq-configure.patch
+    ./libczmq-configure.patch
+    ./sphinx-configure.patch  
+ ];
+
+  # Scripts with not Nix compatible shebangs
+  preAutoreconf = ''
+	patchShebangs ./autogen.sh
+	patchShebangs ./ocamlczmq/autogen.sh
+	patchShebangs ./ocamlczmq/czmq/version.sh
+	patchShebangs ./build.sh
+	patchShebangs ./ocamlczmq/build.sh
+  '';
+
+  autoreconfPhase = ''
+   	runHook preAutoreconf
+   	./autogen.sh
+  '';
+
+  buildPhase = ''
+    mkdir $out
+    export CFLAGS="-Wno-format-security"
+    ./build.sh --prefix=$out  
+  ''
+  +stdenv.lib.optionalString enableManPages
+  ''
+    cd doc/usr
+    make all
+    cd ../..  
+    '';
+
+    postInstall = ""
+    +stdenv.lib.optionalString enableManPages 
+    ''
+      mkdir $doc
+      cp -R doc/usr/build/pdf $doc
+      cp -R doc/usr/build/html $doc
+      cp -R examples $doc 
+    '';  
+
+  nativeBuildInputs = [
+    pkgconfig
+    libtool
+    autoconf
+    automake
+    autoreconfHook
+  ];
+
+  buildInputs = [
+    ocaml-ng.ocamlPackages_4_04.ocaml
+    ocaml-ng.ocamlPackages_4_04.findlib
+    ocaml-ng.ocamlPackages_4_04.ocamlbuild
+    ocaml-ng.ocamlPackages_4_04.menhir
+    ocaml-ng.ocamlPackages_4_04.num
+    ocaml-ng.ocamlPackages_4_04.yojson
+    z3
+    cvc4
+    yices
+  ] 
+  ++ stdenv.lib.optional enableManPages [ 
+    python3 
+    python3.pkgs.sphinx 
+    texliveMk
+    lmodern
+  ];
+}
+

--- a/nix/verification/libczmq-configure.patch
+++ b/nix/verification/libczmq-configure.patch
@@ -1,0 +1,13 @@
+diff --git a/ocamlczmq/libzmq/configure.ac b/ocamlczmq/libzmq/configure.ac
+index ce3eae7b..6bb99ec9 100644
+--- a/ocamlczmq/libzmq/configure.ac
++++ b/ocamlczmq/libzmq/configure.ac
+@@ -128,7 +128,7 @@ fi
+ 
+ 
+ # By default compiling with -Werror except OSX.
+-libzmq_werror="yes"
++libzmq_werror="no"
+ 
+ # By default use DSO visibility
+ libzmq_dso_visibility="yes"

--- a/nix/verification/sphinx-configure.patch
+++ b/nix/verification/sphinx-configure.patch
@@ -1,0 +1,48 @@
+diff --git a/doc/usr/source/conf.py b/doc/usr/source/conf.py
+index ef55592..39088a7 100644
+--- a/doc/usr/source/conf.py
++++ b/doc/usr/source/conf.py
+@@ -75,43 +75,6 @@ exclude_patterns = [
+ # The name of the Pygments (syntax highlighting) style to use.
+ pygments_style = 'sphinx'
+ 
+-
+-# -- Options for HTML output -------------------------------------------------
+-
+-# The theme to use for HTML and HTML Help pages.  See the documentation for
+-# a list of builtin themes.
+-#
+-html_theme = 'press'
+-html_theme_path = ['_themes',]
+-html_css_files = ['css/styles.css',]
+-
+-# Allow us to modify css as we please
+-# https://docs.readthedocs.io/en/latest/guides/adding-custom-css.html#overriding-or-replacing-a-theme-s-stylesheet
+-#
+-html_style = 'css/styles.css'
+-
+-
+-# Theme options are theme-specific and customize the look and feel of a theme
+-# further.  For a list of options available for each theme, see the
+-# documentation.
+-#
+-# html_theme_options = {}
+-
+-# Add any paths that contain custom static files (such as style sheets) here,
+-# relative to this directory. They are copied after the builtin static files,
+-# so a file named "default.css" will overwrite the builtin "default.css".
+-html_static_path = ['_static']
+-
+-# Custom sidebar templates, must be a dictionary that maps document names
+-# to template names.
+-#
+-# The default sidebars (for documents that don't match any pattern) are
+-# defined by theme itself.  Builtin themes are using these templates by
+-# default: ``['localtoc.html', 'relations.html', 'sourcelink.html',
+-# 'searchbox.html']``.
+-#
+-# html_sidebars = {}
+-
+ # -- Options for HTMLHelp output ---------------------------------------------
+ 
+ # Output file base name for HTML help builder.


### PR DESCRIPTION
**Summary**
Kind2 can be tricky to build. The develop branch frequently fails to build and the master branch is outdated for some features. Here a tested, reproducible build process description available through a nix package manager. Run the bootstrap shell script if nix doesn't exist on your linux distribution. 

**Details**
The bootstrapping method is simply to install Nix if it doesn't exist. *Prior to the Windows 10 Creator's Update, the nix installation will fail if done under WSL.* Follow [these instructions](https://dev.to/notriddle/installing-nix-under-wsl-2eim) to fix that.

 